### PR TITLE
fix wagtail 'catch-all' urls and admin override

### DIFF
--- a/aldryn_config.py
+++ b/aldryn_config.py
@@ -30,7 +30,13 @@ class Form(forms.BaseForm):
             'wagtail.wagtailcore.middleware.SiteMiddleware',
             'wagtail.wagtailredirects.middleware.RedirectMiddleware',
         ])
-        settings['ADDON_URLS'].append('aldryn_wagtail.urls')
+        # admin and cms urls need to be first, since we're overriding the
+        # default admin.
+        settings['ADDON_URLS_I18N'].insert(
+            0,
+            'aldryn_wagtail.urls',
+        )
+        settings['ADDON_URLS_I18N_LAST'] = 'aldryn_wagtail.page_urls'
         settings['WAGTAIL_SITE_NAME'] = data['wagtail_site_name']
 
         return settings

--- a/aldryn_wagtail/page_urls.py
+++ b/aldryn_wagtail/page_urls.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+from django.conf.urls import url, include
+
+from wagtail.wagtailcore import urls as wagtail_urls
+
+urlpatterns = [
+    # For anything not caught by a more specific rule, hand over to
+    # Wagtail's serving mechanism
+    url(r'', include(wagtail_urls)),
+]

--- a/aldryn_wagtail/urls.py
+++ b/aldryn_wagtail/urls.py
@@ -5,7 +5,6 @@ from django.contrib import admin
 
 from wagtail.wagtailadmin import urls as wagtailadmin_urls
 from wagtail.wagtaildocs import urls as wagtaildocs_urls
-from wagtail.wagtailcore import urls as wagtail_urls
 from wagtail.contrib.wagtailapi import urls as wagtailapi_urls
 
 urlpatterns = [
@@ -13,8 +12,4 @@ urlpatterns = [
     url(r'^admin/', include(wagtailadmin_urls)),
     url(r'^documents/', include(wagtaildocs_urls)),
     url(r'^api/', include(wagtailapi_urls)),
-    # For anything not caught by a more specific rule above, hand over to
-    # Wagtail's serving mechanism
-    url(r'', include(wagtail_urls)),
 ]
-   


### PR DESCRIPTION
Put the catch-all wagtail.wagtailcore.urls as the very last entry, so
it really can catch all remaining urls. Otherwise other Addons that add
urls would possibly come after the wagtail catch-all and never be used.

Also put the rest of the wagtail urls at the very top, so that wagtail
can override the default admin urls (moved to /django-admin/) and serve
the wagtail admin at /admin/ instead.
