### PR TITLE
Enable wagtail.contrib.modeladmin app

### DIFF
--- a/aldryn_config.py
+++ b/aldryn_config.py
@@ -12,6 +12,7 @@ class Form(forms.BaseForm):
     def to_settings(self, data, settings):
         settings['INSTALLED_APPS'].extend([
             'wagtail.contrib.forms',
+            'wagtail.contrib.modeladmin',
             'wagtail.contrib.redirects',
             'wagtail.embeds',
             'wagtail.sites',


### PR DESCRIPTION
Add `wagtail.contrib.modeladmin` app to the installed apps so developers can use it without having to explicitly enable it.

Reference in the documentation - http://docs.wagtail.io/en/v2.0/reference/contrib/modeladmin/

This module is used by most Wagtail apps that need to have editable models other than pages or snippets which is a fairly common use case. Adding the app won't make any visual changes for the user if developers do not explicitly set their models up with it in `wagtail_hooks.py`. It's a fairly well-respected and stable contrib module.

Enabling this module is purely about convenience, but I feel like it'd be a sane default.