### PR TITLE
Update HomePage model example in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,16 +97,17 @@ Create a ``Page`` model
 
 We need to extend the ``HomePage`` model. Open ``home/models.py`` and replace the entire file with::
 
-    from __future__ import unicode_literals
     from django.db import models
-    from wagtail.wagtailcore.models import Page
-    from wagtail.wagtailcore.fields import RichTextField
-    from wagtail.wagtailadmin.edit_handlers import FieldPanel
+    from wagtail.core.models import Page
+    from wagtail.core.fields import RichTextField
+    from wagtail.admin.edit_handlers import FieldPanel
+
 
     class HomePage(Page):
         body = RichTextField(blank=True)
+
         content_panels = Page.content_panels + [
-            FieldPanel('body', classname="full")
+            FieldPanel('body', classname="full"),
         ]
 
 


### PR DESCRIPTION
Whilst following the tutorial steps in this repo's README, I got the following error for the `makemigrations home` command:

```
  File "/app/home/models.py", line 3, in <module>
    from wagtail.wagtailadmin.edit_handlers import FieldPanel
ModuleNotFoundError: No module named 'wagtail.wagtailadmin'

```

I've updated the docs with the code example used in the [Wagtail docs](http://docs.wagtail.io/en/v2.0/getting_started/tutorial.html#extend-the-homepage-model), which fixes the command for me.