### PR TITLE
Update aldryn_config.py to fix wrongly translated admin URLs

### DIFF
--- a/aldryn_config.py
+++ b/aldryn_config.py
@@ -33,7 +33,8 @@ class Form(forms.BaseForm):
         ])
         # admin and cms urls need to be first, since we're overriding the
         # default admin.
-        settings['ADDON_URLS_I18N'].insert(
+        # These are non-translatable URLs see: https://docs.wagtail.io/en/stable/advanced_topics/i18n.html#adding-a-language-prefix-to-urls
+        settings['ADDON_URLS'].insert(
             0,
             'aldryn_wagtail.urls',
         )

--- a/aldryn_config.py
+++ b/aldryn_config.py
@@ -33,7 +33,7 @@ class Form(forms.BaseForm):
         ])
         # admin and cms urls need to be first, since we're overriding the
         # default admin.
-        # These are non-translatable URLs 
+        # These are non-translatable URLs
         # see: https://docs.wagtail.io/en/stable/advanced_topics/i18n.html#adding-a-language-prefix-to-urls
         settings['ADDON_URLS'].insert(
             0,

--- a/aldryn_config.py
+++ b/aldryn_config.py
@@ -33,7 +33,8 @@ class Form(forms.BaseForm):
         ])
         # admin and cms urls need to be first, since we're overriding the
         # default admin.
-        # These are non-translatable URLs see: https://docs.wagtail.io/en/stable/advanced_topics/i18n.html#adding-a-language-prefix-to-urls
+        # These are non-translatable URLs 
+        # see: https://docs.wagtail.io/en/stable/advanced_topics/i18n.html#adding-a-language-prefix-to-urls
         settings['ADDON_URLS'].insert(
             0,
             'aldryn_wagtail.urls',


### PR DESCRIPTION
Needed to change this otherwise changing the language of a user resulted in a duplicated language code URL chunks and a nice 404 page